### PR TITLE
拦截Apple News的MCC/MNC检测

### DIFF
--- a/sgmodule/Apple_News.sgmodule
+++ b/sgmodule/Apple_News.sgmodule
@@ -13,8 +13,8 @@ PROCESS-NAME,/System/Applications/News.app/Contents/PlugIns/NewsTodayIntents.app
 USER-AGENT,AppleNews*,PROXY
 DOMAIN,news-assets.apple.com,PROXY
 DOMAIN,news-client.apple.com,PROXY
-DOMAIN,news-edge.apple.com,PROXY
-DOMAIN,news-events.apple.com,PROXY
+DOMAIN,news-edge.apple.com,REJECT
+DOMAIN,news-events.apple.com,REJECT-DROP
 DOMAIN,apple.comscoreresearch.com,PROXY
 
 [URL Rewrite]


### PR DESCRIPTION
從http抓包中得知，news-edge.apple.com和news-events.apple.com會發送用戶本機的country code和sim卡 mnc code。把這兩個域名攔截即可解鎖apple news