### PR TITLE
Update Apple_Weather.js

### DIFF
--- a/js/Apple_Weather.js
+++ b/js/Apple_Weather.js
@@ -314,7 +314,7 @@ function outputData(api, stations, obs) {
 // https://github.com/Hackl0us/SS-Rule-Snippet/blob/master/Scripts/Surge/weather_aqi_us/iOS15_Weather_AQI_US.js
 function switchPollutantsType(pollutant) {
     switch (pollutant) {
-        case 'co': return 'CO2';
+        case 'co': return 'CO';
         case 'no': return 'NO';
         case 'no2': return 'NO2';
         case 'so2': return 'SO2';


### PR DESCRIPTION
Pollutant is CO (Carbon monoxide) instead of CO2 (Carbon dioxide) CO2 is not an out-door pollutant and normally will not be monitoring by most of the stations.